### PR TITLE
Move isort settings into pyproject.toml

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -20,6 +20,7 @@ export MORPHEUS_ROOT=${MORPHEUS_ROOT:-"$(realpath ${SCRIPT_DIR}/../..)"}
 
 export PY_ROOT="${MORPHEUS_ROOT}"
 export PY_CFG="${PY_ROOT}/python/morpheus/setup.cfg"
+export PROJ_TOML="${MORPHEUS_ROOT}/pyproject.toml"
 export PY_DIRS="${PY_ROOT} ci/scripts"
 
 # Determine the commits to compare against. If running in CI, these will be set. Otherwise, diff with main

--- a/ci/scripts/python_checks.sh
+++ b/ci/scripts/python_checks.sh
@@ -42,7 +42,7 @@ if [[ -n "${MORPHEUS_MODIFIED_FILES}" ]]; then
    done
 
    if [[ "${SKIP_ISORT}" == "" ]]; then
-      ISORT_OUTPUT=`python3 -m isort --settings-file ${PY_CFG} --filter-files --check-only  ${MORPHEUS_MODIFIED_FILES[@]} 2>&1`
+      ISORT_OUTPUT=`python3 -m isort --settings-file ${PROJ_TOML} --filter-files --check-only  ${MORPHEUS_MODIFIED_FILES[@]} 2>&1`
       ISORT_RETVAL=$?
    fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -719,3 +719,37 @@ ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
+
+
+# ===== isort Config =====
+[tool.isort]
+line_length=120
+multi_line_output=3
+include_trailing_comma=true
+force_grid_wrap=0
+combine_as_imports=true
+order_by_type=true
+force_single_line=true
+src_paths = ["python", "tests"]
+known_dask = ["dask", "distributed", "dask_cuda"]
+known_rapids = ["nvstrings", "nvcategory", "nvtext", "cudf", "cuml", "cugraph", "dask_cudf"]
+known_first_party = ["morpheus", "_utils"]
+default_section = "THIRDPARTY"
+sections= ["FUTURE", "STDLIB", "THIRDPARTY", "DASK", "RAPIDS", "FIRSTPARTY", "LOCALFOLDER"]
+skip= [
+    "__init__.py",
+    # Skip _version.py as it is auto-generated
+    "_version.py",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".tmp",
+    ".tox",
+    ".venv",
+    "buck-out",
+    "build",
+    "dist",
+    "models",
+    "thirdparty"
+]

--- a/python/morpheus/setup.cfg
+++ b/python/morpheus/setup.cfg
@@ -24,50 +24,6 @@ versionfile_build = morpheus/_version.py
 tag_prefix = v
 parentdir_prefix = morpheus-
 
-# ===== isort Config =====
-[isort]
-line_length=120
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-order_by_type=True
-force_single_line=True
-src_paths=morpheus,tests
-known_dask=
-    dask
-    distributed
-    dask_cuda
-known_rapids=
-    nvstrings
-    nvcategory
-    nvtext
-    cudf
-    cuml
-    cugraph
-    dask_cudf
-known_first_party=
-    morpheus
-    _utils
-default_section=THIRDPARTY
-sections=FUTURE,STDLIB,THIRDPARTY,DASK,RAPIDS,FIRSTPARTY,LOCALFOLDER
-skip=
-    __init__.py
-    # Skip _version.py as it is auto-generated
-    _version.py
-    .eggs
-    .git
-    .hg
-    .mypy_cache
-    .tmp
-    .tox
-    .venv
-    buck-out
-    build
-    dist
-    models
-    thirdparty
-
 # ===== flake8 Config =====
 [flake8]
 filename = *.py, *.pyx, *.pxd


### PR DESCRIPTION
## Description
* Fixes isort vscode integration
* Fixes an issue where `tests` was listed in `src_paths` but this was expected to be relative to `python/morpheus`
 
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/nv-morpheus/Morpheus/blob/main/docs/source/developer_guide/contributing.md).
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
